### PR TITLE
Added "captivity.ImpregnateBy" Console Command

### DIFF
--- a/Helper/CEConsole.cs
+++ b/Helper/CEConsole.cs
@@ -560,7 +560,7 @@ namespace CaptivityEvents.Helper
                 ////
                 //Input Validation
                 ////
-                if ((CampaignCheats.CheckParameters(strings, 0) && (CampaignCheats.CheckHelp(strings))) return "Format is \"captivity.ImpregnateBy [HERO] [HERO]\".");
+                if (CampaignCheats.CheckParameters(strings, 0) && CampaignCheats.CheckHelp(strings)) return "Format is \"captivity.ImpregnateBy [HERO] [HERO]\".";
                 
                 bool flagValid = false;
 

--- a/Helper/CEConsole.cs
+++ b/Helper/CEConsole.cs
@@ -549,6 +549,61 @@ namespace CaptivityEvents.Helper
                 return "Sosig\n" + e;
             }
         }
+        
+        [CommandLineFunctionality.CommandLineArgumentFunction("ImpregnateBy", "captivity")]
+        public static string ImpregnateHeroBy(List<string> strings)
+        {
+            try
+            {
+                Thread.Sleep(500);
+                
+                ////
+                //Input Validation
+                ////
+                if ((CampaignCheats.CheckParameters(strings, 0) && (CampaignCheats.CheckHelp(strings))) return "Format is \"captivity.ImpregnateBy [HERO] [HERO]\".";
+                
+                bool flagValid = false;
+
+                string targetName = null;
+                string fromName = null;
+
+                if (CampaignCheats.CheckParameters(strings, 1))
+                {
+                    return "Wrong input.\nFormat is \"captivity.ImpregnateBy [TargetName] [FromName]\". Only 1 String detected.";
+                }
+                else if (CampaignCheats.CheckParameters(strings, 2))
+                {
+                    targetName = strings[0];
+                    fromName = strings[1];
+
+                    if (string.IsNullOrEmpty(targetName) || string.IsNullOrEmpty(fromName)) return "Wrong input.\nFormat is \"captivity.ImpregnateBy [TargetName] [FromName]\".";
+
+                    flagValid = true;
+                }
+
+                if (!flag) return "Wrong input.\nFormat is \"captivity.ImpregnateBy [HERO] [HERO]\".";
+                //End of Validation
+                    
+                CEImpregnationSystem _impregnation = new();
+                    
+                Hero targetHero = Campaign.Current.AliveHeroes.FirstOrDefault(heroToFind => heroToFind.Name.ToString() == targetName);
+                Hero fromHero = Campaign.Current.AliveHeroes.FirstOrDefault(heroToFind => heroToFind.Name.ToString() == fromName);
+                    
+                if (targetHero == null || fromHero == null)
+                {
+                    return "Hero(es) not found.";
+                }
+                else
+                {
+                    _impregnation.ImpregnationChance(targetHero, 0, true, fromHero);
+                    return ("Done. " + targetName + " is now carrying the child of " + fromName);
+                }   
+            }
+            catch (Exception e)
+            {
+                return "Sosig\n" + e;
+            }         
+        }
 
         [CommandLineFunctionality.CommandLineArgumentFunction("current_status", "captivity")]
         public static string CurrentStatus(List<string> strings)

--- a/Helper/CEConsole.cs
+++ b/Helper/CEConsole.cs
@@ -560,7 +560,7 @@ namespace CaptivityEvents.Helper
                 ////
                 //Input Validation
                 ////
-                if ((CampaignCheats.CheckParameters(strings, 0) && (CampaignCheats.CheckHelp(strings))) return "Format is \"captivity.ImpregnateBy [HERO] [HERO]\".";
+                if ((CampaignCheats.CheckParameters(strings, 0) && (CampaignCheats.CheckHelp(strings))) return "Format is \"captivity.ImpregnateBy [HERO] [HERO]\".");
                 
                 bool flagValid = false;
 


### PR DESCRIPTION
This console command is a modification of "Impregnant" which takes a second value in order to search for a hero to serve as the "father" for the target hero being impregnated. There is no gender check in this method as the "ImpregnationChance(...)" method contains this check.

If a female hero is entered as the "fromName" input then the method will complete and call the "ImpregnationChance" method however with it's current behavior it will default the father to be a randomly created hero. In order to allow for female-female impregnation then that method must be altered.

NOTE: I have faith it will work with the above caveat, however it is not tested as I cannot deploy this with my device (as far as I am aware of I cannot, I'm still learning linux for my steamdeck)