### PR TITLE
Dispatch redundant with BL CreateSpecialHero

### DIFF
--- a/Events/CESpawnSystem.cs
+++ b/Events/CESpawnSystem.cs
@@ -138,8 +138,6 @@ namespace CaptivityEvents.Events
                         if (!party.IsMobile) AddHeroToPartyAction.Apply(hero, party.Settlement.Party.MobileParty, true);
                         else AddHeroToPartyAction.Apply(hero, party.MobileParty, true);
                     }
-
-                    CampaignEventDispatcher.Instance.OnHeroCreated(hero, false);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
This line is removed:
                    CampaignEventDispatcher.Instance.OnHeroCreated(hero, false);

It is already called in {BL}.CreateSpecialHero