### PR TITLE
Fix for Bannerlord 1.3.15

### DIFF
--- a/CESubModule.cs
+++ b/CESubModule.cs
@@ -1282,11 +1282,18 @@ namespace CaptivityEvents
             if (game.GameType is not Campaign) return;
             CleanBugs();
             ResetHelper();
-
+            PatchDefaultClanFinanceModel();
             if (!_isLoaded) return;
             InitializeAttributes(game);
             AddBehaviors((CampaignGameStarter)gameStarter);
             CEPersistence.HotButterAvailable = CEHelper.CheckHotButter();
+        }
+
+        private void PatchDefaultClanFinanceModel()
+        {
+            if (!(CESettings.Instance?.ProstitutionControl ?? true)) return;
+            var original = AccessTools.Method(typeof(TaleWorlds.CampaignSystem.GameComponents.DefaultClanFinanceModel), "CalculateClanIncomeInternal");
+            _harmony.Patch(original, postfix: new HarmonyMethod(AccessTools.Method(typeof(Patches.CEPatchDefaultClanFinanceModel), "CalculateClanIncomeInternal")));
         }
 
         private void CleanBugs()

--- a/Patches/CEPatchDefaultClanFinanceModel.cs
+++ b/Patches/CEPatchDefaultClanFinanceModel.cs
@@ -10,13 +10,8 @@ using TaleWorlds.Localization;
 
 namespace CaptivityEvents.Patches
 {
-    [HarmonyPatch(typeof(DefaultClanFinanceModel), "CalculateClanIncomeInternal")]
     internal class CEPatchDefaultClanFinanceModel
     {
-        [HarmonyPrepare]
-        private static bool ShouldPatch() => CESettings.Instance?.ProstitutionControl ?? true;
-
-        [HarmonyPostfix]
         private static void CalculateClanIncomeInternal(Clan clan, ref ExplainedNumber goldChange, bool applyWithdrawals = false, bool includeDetails = false)
         {
             if (clan.IsEliminated) return;

--- a/SubModule.xml
+++ b/SubModule.xml
@@ -2,16 +2,16 @@
 <Module>
   <Name value="Captivity Events" />
   <Id value="zCaptivityEvents" />
-  <Version value="v1.3.13.1312" />
+  <Version value="v1.3.15.1300" />
   <ModuleType value="Community" />
   <ModuleCategory
     value="Singleplayer" />
   <DependedModules>
-    <DependedModule Id="Native" DependentVersion="v1.3.13" />
-    <DependedModule Id="SandBoxCore" DependentVersion="v1.3.13" />
-    <DependedModule Id="Sandbox" DependentVersion="v1.3.13" />
-    <DependedModule Id="CustomBattle" DependentVersion="v1.3.13" />
-    <DependedModule Id="StoryMode" DependentVersion="v1.3.13" />
+    <DependedModule Id="Native" DependentVersion="v1.3.15" />
+    <DependedModule Id="SandBoxCore" DependentVersion="v1.3.15" />
+    <DependedModule Id="Sandbox" DependentVersion="v1.3.15" />
+    <DependedModule Id="CustomBattle" DependentVersion="v1.3.15" />
+    <DependedModule Id="StoryMode" DependentVersion="v1.3.15" />
     <DependedModule Id="Bannerlord.MBOptionScreen" DependentVersion="v5.11.3" Optional="true"/>
   </DependedModules>
 


### PR DESCRIPTION
Gets the mod working with the new version by delaying patching of CalculateClanIncomeInternal until OnGameStart. I suspect the issue is probably related to the introduction of NavalDLCClanFinanceModel. I also suspect the issue might be fixable by replacing the reference to Campaign.Current.Models.ClanFinanceModel with __instance, however in my testing I was unable to get that to work while this fix works perfectly so this is the one I'm submitting.